### PR TITLE
MPA-74_get-parts-of-the-day

### DIFF
--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/ApiHttpClient.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/ApiHttpClient.kt
@@ -6,9 +6,9 @@ import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
 
-
-
 class ApiHttpClient(engine: HttpClientEngine) {
+
+    val url = "http://localhost:3000/api"
 
     val httpClient = HttpClient(engine) {
         install(ContentNegotiation) {

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/PartOfDayApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/PartOfDayApiClient.kt
@@ -14,7 +14,7 @@ class PartOfDayApiClient(engine: HttpClientEngine): IPartOfDayApiClient {
 
     override suspend fun getPartsOfDay(): Result<List<PartOfDayDTO>> {
         return try {
-            val response = httpClient.get("${DefaultData.BASE_URL}/partsDay")
+            val response = httpClient.get("${DefaultData.BASE_URL}/partsday")
 
             if (response.status == HttpStatusCode.OK)
                 return Result.success(response.body())

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/PartOfDayApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/PartOfDayApiClient.kt
@@ -2,25 +2,25 @@ package com.mindera.minderapeople.apiclient
 
 import com.mindera.minderapeople.apiclient.interfaces.IPartOfDayApiClient
 import com.mindera.minderapeople.dto.PartOfDayDTO
-import com.mindera.minderapeople.repository.DefaultData
 import io.ktor.client.call.*
 import io.ktor.client.engine.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 
-class PartOfDayApiClient(engine: HttpClientEngine): IPartOfDayApiClient {
+class PartOfDayApiClient(engine: HttpClientEngine) : IPartOfDayApiClient {
 
-    private val httpClient = ApiHttpClient(engine).httpClient
+    private val apiHttpClient = ApiHttpClient(engine)
+    private val httpClient = apiHttpClient.httpClient
 
     override suspend fun getPartsOfDay(): Result<List<PartOfDayDTO>> {
         return try {
-            val response = httpClient.get("${DefaultData.BASE_URL}/partsday")
+            val response = httpClient.get("${apiHttpClient.url}/partsday")
 
-            if (response.status == HttpStatusCode.OK)
+            if (response.status == HttpStatusCode.OK) {
                 return Result.success(response.body())
-            else
+            } else {
                 return Result.failure(Exception(response.status.description))
-
+            }
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/PartOfDayApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/PartOfDayApiClient.kt
@@ -1,0 +1,29 @@
+package com.mindera.minderapeople.apiclient
+
+import com.mindera.minderapeople.apiclient.interfaces.IPartOfDayApiClient
+import com.mindera.minderapeople.dto.PartOfDayDTO
+import com.mindera.minderapeople.repository.DefaultData
+import io.ktor.client.call.*
+import io.ktor.client.engine.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+
+class PartOfDayApiClient(engine: HttpClientEngine): IPartOfDayApiClient {
+
+    private val httpClient = ApiHttpClient(engine).httpClient
+
+    override suspend fun getPartsOfDay(): Result<List<PartOfDayDTO>> {
+        return try {
+            val response = httpClient.get("${DefaultData.BASE_URL}/partsDay")
+
+            if (response.status == HttpStatusCode.OK)
+                return Result.success(response.body())
+            else
+                return Result.failure(Exception(response.status.description))
+
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+}

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/interfaces/IPartOfDayApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/interfaces/IPartOfDayApiClient.kt
@@ -1,0 +1,9 @@
+package com.mindera.minderapeople.apiclient.interfaces
+
+import com.mindera.minderapeople.dto.PartOfDayDTO
+
+interface IPartOfDayApiClient {
+
+    suspend fun getPartsOfDay(): Result<List<PartOfDayDTO>>
+
+}

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/dto/PartOfDayDTO.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/dto/PartOfDayDTO.kt
@@ -1,6 +1,12 @@
 package com.mindera.minderapeople.dto
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class PartOfDayDTO(val aux:String)
+data class PartOfDayDTO(
+    val id: String,
+    val description: String,
+    @SerialName("icon_name")
+    val iconName: String
+)

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/DefaultData.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/DefaultData.kt
@@ -2,5 +2,10 @@ package com.mindera.minderapeople.repository
 
 object DefaultData {
 
+    //API
+    const val BASE_URL = "http://localhost:3000/api"
+
+    //Error messages
     const val INVALID_USER_ID = "Invalid User ID format"
+
 }

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/DefaultData.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/DefaultData.kt
@@ -2,9 +2,6 @@ package com.mindera.minderapeople.repository
 
 object DefaultData {
 
-    //API
-    const val BASE_URL = "http://localhost:3000/api"
-
     //Error messages
     const val INVALID_USER_ID = "Invalid User ID format"
 

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/PartOfDayRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/PartOfDayRepository.kt
@@ -4,7 +4,7 @@ import com.mindera.minderapeople.apiclient.interfaces.IPartOfDayApiClient
 import com.mindera.minderapeople.dto.PartOfDayDTO
 import com.mindera.minderapeople.repository.interfaces.IPartOfDayRepository
 
-class PartOfDayRepository(private val apiClient: IPartOfDayApiClient): IPartOfDayRepository {
+class PartOfDayRepository(private val apiClient: IPartOfDayApiClient) : IPartOfDayRepository {
 
     override suspend fun getPartsOfDay(): Result<List<PartOfDayDTO>> {
         return apiClient.getPartsOfDay()

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/PartOfDayRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/PartOfDayRepository.kt
@@ -1,6 +1,12 @@
 package com.mindera.minderapeople.repository
 
-import com.mindera.minderapeople.MinderaPeopleAPIClient
+import com.mindera.minderapeople.apiclient.interfaces.IPartOfDayApiClient
+import com.mindera.minderapeople.dto.PartOfDayDTO
+import com.mindera.minderapeople.repository.interfaces.IPartOfDayRepository
 
-class PartOfDayRepository(val apiClient: MinderaPeopleAPIClient) {
+class PartOfDayRepository(private val apiClient: IPartOfDayApiClient): IPartOfDayRepository {
+
+    override suspend fun getPartsOfDay(): Result<List<PartOfDayDTO>> {
+        return apiClient.getPartsOfDay()
+    }
 }

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/interfaces/IPartOfDayRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/interfaces/IPartOfDayRepository.kt
@@ -1,0 +1,8 @@
+package com.mindera.minderapeople.repository.interfaces
+
+import com.mindera.minderapeople.dto.PartOfDayDTO
+
+interface IPartOfDayRepository {
+
+    suspend fun getPartsOfDay(): Result<List<PartOfDayDTO>>
+}

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/integration/partofday/PartOfDayIntegrationTests.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/integration/partofday/PartOfDayIntegrationTests.kt
@@ -1,0 +1,55 @@
+package com.mindera.minderapeople.integration.partofday
+
+import com.mindera.minderapeople.apiclient.PartOfDayApiClient
+import com.mindera.minderapeople.mocks.DefaultTestData
+import com.mindera.minderapeople.repository.PartOfDayRepository
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PartOfDayIntegrationTests {
+
+    @Test
+    fun getAllPartsOfDay_successful() {
+        val mockEngine = MockEngine {
+            respond(
+                content = ByteReadChannel(Json.encodeToString(DefaultTestData.SUCCESSFUL_3_PARTS_OF_DAY)),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val apiClient = PartOfDayApiClient(mockEngine)
+        val repo = PartOfDayRepository(apiClient)
+
+        runBlocking {
+            val result = repo.getPartsOfDay()
+            assertTrue(result.isSuccess)
+            assertEquals(3, result.getOrNull()?.size)
+            assertEquals(DefaultTestData.SUCCESSFUL_3_PARTS_OF_DAY, result.getOrNull())
+        }
+    }
+
+    @Test
+    fun getAllPartsOfDay_badRequest() {
+        val mockEngine = MockEngine {
+            respondError(
+                status = HttpStatusCode.BadRequest
+            )
+        }
+        val apiClient = PartOfDayApiClient(mockEngine)
+        val repo = PartOfDayRepository(apiClient)
+
+        runBlocking {
+            val result = repo.getPartsOfDay()
+            assertTrue(result.isFailure)
+            assertEquals(null, result.getOrNull())
+            assertEquals(HttpStatusCode.BadRequest.description, result.exceptionOrNull()?.message)
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/mocks/DefaultTestData.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/mocks/DefaultTestData.kt
@@ -1,5 +1,6 @@
 package com.mindera.minderapeople.mocks
 
+import com.mindera.minderapeople.dto.PartOfDayDTO
 import com.mindera.minderapeople.dto.PolicyDTO
 
 object DefaultTestData {
@@ -8,5 +9,11 @@ object DefaultTestData {
         PolicyDTO("0001", "Work from home", "defaultIcon"),
         PolicyDTO("0002", "Holidays", "defaultIcon", 5, 20),
         PolicyDTO("0002", "Sick Day", "defaultIcon")
+    )
+
+    val SUCCESSFUL_3_PARTS_OF_DAY = listOf(
+        PartOfDayDTO("0001", "Morning", "defaultIcon"),
+        PartOfDayDTO("0002", "Afternoon", "defaultIcon"),
+        PartOfDayDTO("0003", "Full day", "defaultIcon")
     )
 }

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/mocks/PartOfDayApiClientMock.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/mocks/PartOfDayApiClientMock.kt
@@ -3,7 +3,7 @@ package com.mindera.minderapeople.mocks
 import com.mindera.minderapeople.apiclient.interfaces.IPartOfDayApiClient
 import com.mindera.minderapeople.dto.PartOfDayDTO
 
-class PartOfDayApiClientMock: IPartOfDayApiClient {
+class PartOfDayApiClientMock : IPartOfDayApiClient {
 
     override suspend fun getPartsOfDay(): Result<List<PartOfDayDTO>> {
         return Result.success(DefaultTestData.SUCCESSFUL_3_PARTS_OF_DAY)

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/mocks/PartOfDayApiClientMock.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/mocks/PartOfDayApiClientMock.kt
@@ -1,0 +1,11 @@
+package com.mindera.minderapeople.mocks
+
+import com.mindera.minderapeople.apiclient.interfaces.IPartOfDayApiClient
+import com.mindera.minderapeople.dto.PartOfDayDTO
+
+class PartOfDayApiClientMock: IPartOfDayApiClient {
+
+    override suspend fun getPartsOfDay(): Result<List<PartOfDayDTO>> {
+        return Result.success(DefaultTestData.SUCCESSFUL_3_PARTS_OF_DAY)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/apiclient/PartOfDayApiClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/apiclient/PartOfDayApiClientTest.kt
@@ -1,0 +1,69 @@
+package com.mindera.minderapeople.unit.apiclient
+
+import com.mindera.minderapeople.apiclient.PartOfDayApiClient
+import com.mindera.minderapeople.mocks.DefaultTestData
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PartOfDayApiClientTest {
+
+    @Test
+    fun getAllPartsOfDay_successful() {
+        val mockEngine = MockEngine {
+            respond(
+                content = ByteReadChannel(Json.encodeToString(DefaultTestData.SUCCESSFUL_3_PARTS_OF_DAY)),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+
+        runBlocking {
+            val client = PartOfDayApiClient(mockEngine)
+            val result = client.getPartsOfDay()
+
+            assertEquals(3, result.getOrNull()?.size)
+            assertEquals(DefaultTestData.SUCCESSFUL_3_PARTS_OF_DAY, result.getOrNull())
+            assertTrue(result.isSuccess)
+        }
+    }
+
+    @Test
+    fun getAllPartsOfDay_badRequest() {
+        val mockEngine = MockEngine {
+            respondBadRequest()
+        }
+
+        runBlocking {
+            val client = PartOfDayApiClient(mockEngine)
+            val result = client.getPartsOfDay()
+
+            assertEquals(null, result.getOrNull())
+            assertEquals(HttpStatusCode.BadRequest.description, result.exceptionOrNull()?.message)
+            assertTrue(result.isFailure)
+        }
+    }
+
+    @Test
+    fun getAllPoliciesForUser_Exception() {
+        val errorMessage = "Error"
+        val mockEngine = MockEngine {
+            throw Exception(errorMessage)
+        }
+
+        runBlocking {
+            val client = PartOfDayApiClient(mockEngine)
+            val result = client.getPartsOfDay()
+
+            assertTrue(result.isFailure)
+            assertEquals(null, result.getOrNull())
+            assertEquals(errorMessage, result.exceptionOrNull()?.message)
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/repository/PartOfDayRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/repository/PartOfDayRepositoryTest.kt
@@ -1,0 +1,26 @@
+package com.mindera.minderapeople.unit.repository
+
+import com.mindera.minderapeople.mocks.DefaultTestData
+import com.mindera.minderapeople.mocks.PartOfDayApiClientMock
+import com.mindera.minderapeople.repository.PartOfDayRepository
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PartOfDayRepositoryTest {
+
+    @Test
+    fun getAllPartOfDay_successful() {
+        val client = PartOfDayApiClientMock()
+        val repo = PartOfDayRepository(client)
+
+        runBlocking {
+            val result = repo.getPartsOfDay()
+
+            assertTrue(result.isSuccess)
+            assertEquals(3, result.getOrNull()?.size)
+            assertEquals(DefaultTestData.SUCCESSFUL_3_PARTS_OF_DAY, result.getOrNull())
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/repository/PolicyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/repository/PolicyRepositoryTest.kt
@@ -1,16 +1,14 @@
 package com.mindera.minderapeople.unit.repository
 
-import com.mindera.minderapeople.repository.DefaultData
-import com.mindera.minderapeople.repository.PolicyRepository
 import com.mindera.minderapeople.mocks.DefaultTestData
 import com.mindera.minderapeople.mocks.PolicyApiClientMock
+import com.mindera.minderapeople.repository.DefaultData
+import com.mindera.minderapeople.repository.PolicyRepository
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
-
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
 
 class PolicyRepositoryTest {
 


### PR DESCRIPTION
This PR has the implementation of the network layer that does the API requests to get the list of parts of the day.
The following diagram shows how it was implemented

![GetPartsOfDay](https://user-images.githubusercontent.com/126101431/229460565-c2a5b0a8-c746-47bc-b72f-ac6bfc7c9e9f.svg)

