### PR TITLE
Mpa 73 get projects

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("multiplatform")
     id("com.android.library")
     id("com.chromaticnoise.multiplatform-swiftpackage") version "2.0.3"
+    kotlin("plugin.serialization") version "1.8.10"
 }
 
 kotlin {
@@ -34,10 +35,15 @@ kotlin {
     }
 
     sourceSets {
+        val ktorVersion = "2.2.4"
         val commonMain by getting {
             dependencies{
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.3.1")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.1")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.4.1")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
+                implementation("io.ktor:ktor-client-core:$ktorVersion")
+                implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
+                implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
             }
         }
         val commonTest by getting {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("com.android.library")
     id("com.chromaticnoise.multiplatform-swiftpackage") version "2.0.3"
     kotlin("plugin.serialization") version "1.8.10"
+    id("com.google.devtools.ksp") version "1.8.0-1.0.9"
 }
 
 kotlin {
@@ -49,6 +50,10 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
+                implementation("io.ktor:ktor-client-mock:$ktorVersion")
+                implementation("org.jetbrains.kotlin:kotlin-test")
+                implementation("io.mockative:mockative:1.4.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
             }
         }
         val androidMain by getting
@@ -72,6 +77,14 @@ kotlin {
             iosSimulatorArm64Test.dependsOn(this)
         }
     }
+}
+
+dependencies {
+    configurations
+        .filter { it.name.startsWith("ksp") && it.name.contains("Test") }
+        .forEach {
+            add(it.name, "io.mockative:mockative-processor:1.4.0")
+        }
 }
 
 android {

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/DTO/ProjectDTO.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/DTO/ProjectDTO.kt
@@ -1,9 +1,0 @@
-package com.mindera.minderapeople.DTO
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class ProjectDTO(
-    val project_id: String,
-    val project_name: String
-)

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/DTO/ProjectDTO.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/DTO/ProjectDTO.kt
@@ -3,4 +3,7 @@ package com.mindera.minderapeople.DTO
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ProjectDTO(val aux:String)
+data class ProjectDTO(
+    val project_id: String,
+    val project_name: String
+)

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/MinderaPeopleAPIClient.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/MinderaPeopleAPIClient.kt
@@ -1,4 +1,20 @@
 package com.mindera.minderapeople
 
-class MinderaPeopleAPIClient {
+import io.ktor.client.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.json.Json
+
+object  MinderaPeopleAPIClient {
+
+    const val BASE_URL = "http://localhost:3000/api"
+
+    val httpClient = HttpClient {
+        install(ContentNegotiation) {
+            json(Json {
+                ignoreUnknownKeys = true
+                useAlternativeNames = false
+            })
+        }
+    }
 }

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/MinderaPeopleAPIClient.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/MinderaPeopleAPIClient.kt
@@ -1,15 +1,17 @@
-package com.mindera.minderapeople
+package com.mindera.minderapeople.apiclient
 
 import io.ktor.client.*
+import io.ktor.client.engine.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
 
-object  MinderaPeopleAPIClient {
+class  MinderaPeopleAPIClient(engine:HttpClientEngine) {
+    companion object {
+        const val BASE_URL = "http://localhost:3000/api"
+    }
 
-    const val BASE_URL = "http://localhost:3000/api"
-
-    val httpClient = HttpClient {
+    val httpClient = HttpClient (engine){
         install(ContentNegotiation) {
             json(Json {
                 ignoreUnknownKeys = true

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/ProjectApiClientImpI.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/ProjectApiClientImpI.kt
@@ -1,0 +1,22 @@
+package com.mindera.minderapeople.apiclient
+
+import com.mindera.minderapeople.DTO.ProjectDTO
+import com.mindera.minderapeople.MinderaPeopleAPIClient
+import com.mindera.minderapeople.apiclient.interfaces.IProjectsApiClient
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+
+class ProjectApiClientImpl: IProjectsApiClient {
+
+    val httpClient = MinderaPeopleAPIClient.httpClient
+    val baseUrl = MinderaPeopleAPIClient.BASE_URL
+
+    override suspend fun getAllProjects(): Result<List<ProjectDTO>> {
+        return try{
+            val response: List<ProjectDTO> = httpClient.get("${baseUrl}/policies").body()
+            Result.success(response)
+        }catch (e: Exception){
+            Result.failure(e)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/ProjectApiClientImpI.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/ProjectApiClientImpI.kt
@@ -1,20 +1,25 @@
 package com.mindera.minderapeople.apiclient
 
-import com.mindera.minderapeople.DTO.ProjectDTO
-import com.mindera.minderapeople.MinderaPeopleAPIClient
+import com.mindera.minderapeople.dto.ProjectDTO
 import com.mindera.minderapeople.apiclient.interfaces.IProjectsApiClient
 import io.ktor.client.call.*
+import io.ktor.client.engine.*
 import io.ktor.client.request.*
+import io.ktor.http.*
 
-class ProjectApiClientImpl: IProjectsApiClient {
+class ProjectApiClientImpl (engine: HttpClientEngine): IProjectsApiClient {
 
-    val httpClient = MinderaPeopleAPIClient.httpClient
-    val baseUrl = MinderaPeopleAPIClient.BASE_URL
+    private val httpClient = MinderaPeopleAPIClient(engine).httpClient
+    private val baseUrl = MinderaPeopleAPIClient.BASE_URL
 
     override suspend fun getAllProjects(): Result<List<ProjectDTO>> {
         return try{
-            val response: List<ProjectDTO> = httpClient.get("${baseUrl}/policies").body()
-            Result.success(response)
+            val response = httpClient.get("${baseUrl}/policies")
+
+            if(response.status == HttpStatusCode.OK)
+                Result.success(response.body())
+            else
+                Result.failure(Exception(response.status.description))
         }catch (e: Exception){
             Result.failure(e)
         }

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/interfaces/IProjectsApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/interfaces/IProjectsApiClient.kt
@@ -1,6 +1,6 @@
 package com.mindera.minderapeople.apiclient.interfaces
 
-import com.mindera.minderapeople.DTO.ProjectDTO
+import com.mindera.minderapeople.dto.ProjectDTO
 
 interface IProjectsApiClient {
     suspend fun getAllProjects(): Result<List<ProjectDTO>>

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/interfaces/IProjectsApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/interfaces/IProjectsApiClient.kt
@@ -1,0 +1,7 @@
+package com.mindera.minderapeople.apiclient.interfaces
+
+import com.mindera.minderapeople.DTO.ProjectDTO
+
+interface IProjectsApiClient {
+    suspend fun getAllProjects(): Result<List<ProjectDTO>>
+}

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/dto/EventDTO.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/dto/EventDTO.kt
@@ -1,4 +1,4 @@
-package com.mindera.minderapeople.DTO
+package com.mindera.minderapeople.dto
 
 import kotlinx.serialization.Serializable
 

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/dto/PartOfDayDTO.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/dto/PartOfDayDTO.kt
@@ -1,4 +1,4 @@
-package com.mindera.minderapeople.DTO
+package com.mindera.minderapeople.dto
 
 import kotlinx.serialization.Serializable
 

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/dto/PolicyDTO.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/dto/PolicyDTO.kt
@@ -1,4 +1,4 @@
-package com.mindera.minderapeople.DTO
+package com.mindera.minderapeople.dto
 
 import kotlinx.serialization.Serializable
 

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/dto/ProjectDTO.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/dto/ProjectDTO.kt
@@ -1,0 +1,10 @@
+package com.mindera.minderapeople.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ProjectDTO(
+    @SerialName("id") val id: String? = null,
+    @SerialName("project_name") val projectName: String? = null
+)

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/EventRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/EventRepository.kt
@@ -1,6 +1,6 @@
 package com.mindera.minderapeople.repository
 
-import com.mindera.minderapeople.MinderaPeopleAPIClient
+import com.mindera.minderapeople.apiclient.MinderaPeopleAPIClient
 
 class EventRepository(val apiClient: MinderaPeopleAPIClient) {
 }

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/PartOfDayRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/PartOfDayRepository.kt
@@ -1,6 +1,6 @@
 package com.mindera.minderapeople.repository
 
-import com.mindera.minderapeople.MinderaPeopleAPIClient
+import com.mindera.minderapeople.apiclient.MinderaPeopleAPIClient
 
 class PartOfDayRepository(val apiClient: MinderaPeopleAPIClient) {
 }

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/PolicyRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/PolicyRepository.kt
@@ -1,6 +1,6 @@
 package com.mindera.minderapeople.repository
 
-import com.mindera.minderapeople.MinderaPeopleAPIClient
+import com.mindera.minderapeople.apiclient.MinderaPeopleAPIClient
 
 class PolicyRepository(val apiClient: MinderaPeopleAPIClient) {
 }

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/ProjectRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/ProjectRepository.kt
@@ -1,6 +1,0 @@
-package com.mindera.minderapeople.repository
-
-import com.mindera.minderapeople.MinderaPeopleAPIClient
-
-class ProjectRepository(val apiClient: MinderaPeopleAPIClient) {
-}

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/ProjectRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/ProjectRepositoryImpl.kt
@@ -1,10 +1,10 @@
 package com.mindera.minderapeople.repository
 
-import com.mindera.minderapeople.DTO.ProjectDTO
+import com.mindera.minderapeople.dto.ProjectDTO
 import com.mindera.minderapeople.apiclient.interfaces.IProjectsApiClient
 import com.mindera.minderapeople.repository.interfaces.IProjectRepository
 
-class ProjectRepositoryImpl(val apiClient: IProjectsApiClient) : IProjectRepository{
+class ProjectRepositoryImpl(private val apiClient: IProjectsApiClient) : IProjectRepository{
     override suspend fun getAllProjects(): Result<List<ProjectDTO>> {
         return apiClient.getAllProjects()
     }

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/ProjectRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/ProjectRepositoryImpl.kt
@@ -1,0 +1,12 @@
+package com.mindera.minderapeople.repository
+
+import com.mindera.minderapeople.DTO.ProjectDTO
+import com.mindera.minderapeople.apiclient.interfaces.IProjectsApiClient
+import com.mindera.minderapeople.repository.interfaces.IProjectRepository
+
+class ProjectRepositoryImpl(val apiClient: IProjectsApiClient) : IProjectRepository{
+    override suspend fun getAllProjects(): Result<List<ProjectDTO>> {
+        return apiClient.getAllProjects()
+    }
+
+}

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/interfaces/IProjectRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/interfaces/IProjectRepository.kt
@@ -1,6 +1,6 @@
 package com.mindera.minderapeople.repository.interfaces
 
-import com.mindera.minderapeople.DTO.ProjectDTO
+import com.mindera.minderapeople.dto.ProjectDTO
 
 interface IProjectRepository {
     suspend fun getAllProjects(): Result<List<ProjectDTO>>

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/interfaces/IProjectRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/interfaces/IProjectRepository.kt
@@ -1,0 +1,7 @@
+package com.mindera.minderapeople.repository.interfaces
+
+import com.mindera.minderapeople.DTO.ProjectDTO
+
+interface IProjectRepository {
+    suspend fun getAllProjects(): Result<List<ProjectDTO>>
+}

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/apiClient/ProjectApiClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/apiClient/ProjectApiClientTest.kt
@@ -1,0 +1,106 @@
+package com.mindera.minderapeople.unit.apiClient
+
+import com.mindera.minderapeople.apiclient.ProjectApiClientImpl
+import kotlin.test.Test
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.runBlocking
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ProjectApiClientTest {
+
+    private val validResponseWithElements = """
+        [
+            {
+                "id": "anova0001",
+                "project_name": "Anova(Unify)"
+            },
+            {
+                "id": "farfetch0001",
+                "project_name": "Farfetch (PH Portugal)"
+            },
+            {
+                "id": "farfetch0002",
+                "project_name": "Farfetch (FF Harrods)"
+            }
+        ]
+    """
+
+    private val validResponseWithoutElements = """[]"""
+
+
+    @Test
+    fun `test getAllProjects returns success and a list if API request was valid and there are objects`() {
+        val mockEngine = MockEngine { request ->
+            respond(
+                content = ByteReadChannel(validResponseWithElements),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+
+        runBlocking {
+            val client = ProjectApiClientImpl(mockEngine)
+            val result = client.getAllProjects()
+
+            assertTrue(result.isSuccess)
+            assertEquals(3, result.getOrNull()?.size)
+        }
+    }
+
+    @Test
+    fun `test getAllProjects returns success and an empty list if API request was valid and there are no objects`() {
+        val mockEngine = MockEngine { request ->
+            respond(
+                content = ByteReadChannel(validResponseWithoutElements),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+
+        runBlocking {
+            val client = ProjectApiClientImpl(mockEngine)
+            val result = client.getAllProjects()
+
+            assertTrue(result.isSuccess)
+            assertEquals(0, result.getOrNull()?.size)
+        }
+    }
+
+    @Test
+    fun `test getAllProjects returns failure if badRequest`() {
+
+        val mockEngine = MockEngine {
+            respondBadRequest()
+        }
+
+        runBlocking {
+            val client = ProjectApiClientImpl(mockEngine)
+            val result = client.getAllProjects()
+
+            assertTrue(result.isFailure)
+            assertEquals(null, result.getOrNull())
+            assertEquals(HttpStatusCode.BadRequest.description, result.exceptionOrNull()?.message)
+        }
+    }
+
+    @Test
+    fun `test getAllProjects returns failure when Exception is thrown`() {
+        val errorMessage = "Error"
+
+        val mockEngine = MockEngine {
+            throw Exception(errorMessage)
+        }
+
+        runBlocking {
+            val client = ProjectApiClientImpl(mockEngine)
+            val result = client.getAllProjects()
+
+            assertTrue(result.isFailure)
+            assertEquals(null, result.getOrNull())
+            assertEquals(errorMessage, result.exceptionOrNull()?.message)
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/repository/ProjectRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/repository/ProjectRepositoryTest.kt
@@ -58,7 +58,7 @@ class ProjectRepositoryTest {
      }
 
      @Test
-     fun `test getAllProjects returns failure if badRequest`() {
+     fun `test getAllProjects returns failure`() {
           val errorMessage = "Server could not handle request"
 
           given(api).suspendFunction(api::getAllProjects)

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/repository/ProjectRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/repository/ProjectRepositoryTest.kt
@@ -1,0 +1,77 @@
+package com.mindera.minderapeople.unit.repository
+
+import com.mindera.minderapeople.apiclient.interfaces.IProjectsApiClient
+import com.mindera.minderapeople.dto.ProjectDTO
+import com.mindera.minderapeople.repository.ProjectRepositoryImpl
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+
+class ProjectRepositoryTest {
+     @Mock
+     private val api = mock(classOf<IProjectsApiClient>())
+
+     private val validResponseWithElements = listOf(
+          ProjectDTO("anova0001","Anova(Unify)"),
+          ProjectDTO("farfetch0001","Farfetch (PH Portugal)"),
+          ProjectDTO("farfetch0002","Farfetch (FF Harrods)")
+     )
+
+     private val validResponseWithoutElements = listOf<ProjectDTO>()
+
+     @Test
+     fun `test getAllProjects returns success and a list if API request was valid and there are objects`(){
+          given(api).suspendFunction(api::getAllProjects)
+               .whenInvoked()
+               .then { Result.success(validResponseWithElements) }
+          val projectRepo = ProjectRepositoryImpl(api)
+
+          runBlocking {
+               val result = projectRepo.getAllProjects()
+
+               assertTrue(result.isSuccess)
+               assertEquals(3, result.getOrNull()?.size)
+               assertEquals(validResponseWithElements, result.getOrNull())
+          }
+     }
+
+     @Test
+     fun `test getAllProjects returns success and a empty list if API request was valid and there are no objects`() {
+          given(api).suspendFunction(api::getAllProjects)
+               .whenInvoked()
+               .then { Result.success(validResponseWithoutElements) }
+          val projectRepo = ProjectRepositoryImpl(api)
+
+          runBlocking {
+               val result = projectRepo.getAllProjects()
+
+               assertTrue(result.isSuccess)
+               assertEquals(0, result.getOrNull()?.size)
+               assertEquals(validResponseWithoutElements, result.getOrNull())
+          }
+     }
+
+     @Test
+     fun `test getAllProjects returns failure if badRequest`() {
+          val errorMessage = "Server could not handle request"
+
+          given(api).suspendFunction(api::getAllProjects)
+               .whenInvoked()
+               .then{ Result.failure(Exception(errorMessage))}
+          val projectRepo = ProjectRepositoryImpl(api)
+
+          runBlocking {
+               val result = projectRepo.getAllProjects()
+
+               assertTrue(result.isFailure)
+               assertEquals(null, result.getOrNull())
+               assertEquals(errorMessage, result.exceptionOrNull()?.message)
+          }
+     }
+}


### PR DESCRIPTION
Getting all projects from the API
The following diagram shows how it was implemented
![projects](https://user-images.githubusercontent.com/126094857/229467637-63faee88-6fa5-47a9-b9f6-9c644e1ef238.jpg)
The Ktor plugin was used for the http requests to the APi, for the serialization of the data classes and the mocking of the Http requests to the API
For the mocking of the the ProjectApiClient class for the unit tests of the ProjectRepository, Mockative was used which uses the ksp plugin