### PR TITLE
MPA-70_get-events

### DIFF
--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/EventApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/EventApiClient.kt
@@ -1,6 +1,8 @@
 package com.mindera.minderapeople.apiclient
 
 import com.mindera.minderapeople.apiclient.interfaces.IEventApiClient
+import com.mindera.minderapeople.dto.EventDTO
+import io.ktor.client.call.*
 import io.ktor.client.engine.*
 import io.ktor.client.request.*
 import io.ktor.http.*
@@ -9,6 +11,20 @@ class EventApiClient(engine: HttpClientEngine) : IEventApiClient {
 
     private val apiHttpClient = ApiHttpClient(engine)
     private val httpClient = apiHttpClient.httpClient
+
+    override suspend fun getAllEventsForUser(userId: String): Result<List<EventDTO>> {
+        return try {
+            val response = httpClient.get("${apiHttpClient.url}/events/${userId}")
+
+            if (response.status == HttpStatusCode.OK) {
+                Result.success(response.body())
+            } else {
+                Result.failure(Exception(response.status.description))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
 
     override suspend fun removeEventById(userId: String, eventId: String): Result<Nothing?> {
         return try {
@@ -23,5 +39,4 @@ class EventApiClient(engine: HttpClientEngine) : IEventApiClient {
             Result.failure(e)
         }
     }
-
 }

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/interfaces/IEventApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/apiclient/interfaces/IEventApiClient.kt
@@ -1,6 +1,9 @@
 package com.mindera.minderapeople.apiclient.interfaces
 
+import com.mindera.minderapeople.dto.EventDTO
+
 interface IEventApiClient {
 
+    suspend fun getAllEventsForUser(userId: String): Result<List<EventDTO>>
     suspend fun removeEventById(userId: String, eventId: String): Result<Nothing?>
 }

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/EventRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/EventRepository.kt
@@ -6,6 +6,10 @@ import com.mindera.minderapeople.repository.interfaces.IEventRepository
 
 class EventRepository(private val apiClient: IEventApiClient) : IEventRepository {
 
+    override suspend fun getAllEventsForUser(userId: String): Result<List<EventDTO>> {
+        return apiClient.getAllEventsForUser(userId)
+    }
+
     override suspend fun removeEventById(userId: String, event: EventDTO): Result<Nothing?> {
         return apiClient.removeEventById(userId, event.id)
     }

--- a/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/interfaces/IEventRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mindera/minderapeople/repository/interfaces/IEventRepository.kt
@@ -4,5 +4,6 @@ import com.mindera.minderapeople.dto.EventDTO
 
 interface IEventRepository {
 
+    suspend fun getAllEventsForUser(userId: String): Result<List<EventDTO>>
     suspend fun removeEventById(userId: String, event: EventDTO): Result<Nothing?>
 }

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/integration/event/EventIntegrationTests.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/integration/event/EventIntegrationTests.kt
@@ -7,11 +7,66 @@ import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class EventIntegrationTests {
+
+    @Test
+    fun getAllEventsForUser_successful() {
+        val mockEngine = MockEngine {
+            respond(
+                content = ByteReadChannel(Json.encodeToString(DefaultTestData.EVENT_LIST)),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val apiClient = EventApiClient(mockEngine)
+        val repo = EventRepository(apiClient)
+
+        runBlocking {
+            val result = repo.getAllEventsForUser(DefaultTestData.USER_ID_CORRECT)
+
+            assertTrue(result.isSuccess)
+            assertEquals(DefaultTestData.EVENT_LIST, result.getOrNull())
+        }
+    }
+
+    @Test
+    fun getAllEventsForUser_userNotFound() {
+        val mockEngine = MockEngine {
+            respondError(HttpStatusCode.NotFound)
+        }
+        val apiClient = EventApiClient(mockEngine)
+        val repo = EventRepository(apiClient)
+
+        runBlocking {
+            val result = repo.getAllEventsForUser("0001")
+
+            assertTrue(result.isFailure)
+            assertEquals(null, result.getOrNull())
+            assertEquals(HttpStatusCode.NotFound.description, result.exceptionOrNull()?.message)
+        }
+    }
+
+    @Test
+    fun getAllEventsForUser_exceptionThrown() {
+        val error = "Error occurred"
+        val mockEngine = MockEngine {
+            throw Exception(error)
+        }
+        val apiClient = EventApiClient(mockEngine)
+        val repo = EventRepository(apiClient)
+
+        runBlocking {
+            val result = repo.getAllEventsForUser(DefaultTestData.USER_ID_CORRECT)
+            assertTrue(result.isFailure)
+            assertEquals(error, result.exceptionOrNull()?.message)
+        }
+    }
 
     @Test
     fun removeEventById_successful() {
@@ -27,6 +82,7 @@ class EventIntegrationTests {
 
         runBlocking {
             val result = repo.removeEventById(DefaultTestData.USER_ID_CORRECT, DefaultTestData.CORRECT_EVENT)
+
             assertTrue(result.isSuccess)
             assertEquals(null, result.getOrNull())
         }

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/mocks/DefaultTestData.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/mocks/DefaultTestData.kt
@@ -51,4 +51,67 @@ object DefaultTestData {
             "default"
         )
     )
+    val EVENT_LIST = listOf(
+        EventDTO(
+            "f4b20503-0a30-4e76-8796-aee78726139f",
+            PolicyDTO(
+                "0001",
+                "Travel",
+                "default"
+            ),
+            "2023-04-03",
+            "2023-04-10",
+            PartOfDayDTO(
+                "0001",
+                "Full day",
+                "default"
+            )
+        ),
+        EventDTO(
+            "f4b20503-0a30-4e76-8796-aee787261387",
+            PolicyDTO(
+                "0002",
+                "Sick day",
+                "default"
+            ),
+            "2023-05-03",
+            "2023-05-10",
+            PartOfDayDTO(
+                "0002",
+                "Morning",
+                "default"
+            )
+        ),
+        EventDTO(
+            "f4b20503-0a30-4e76-8796-aee787261399",
+            PolicyDTO(
+                "0003",
+                "Holidays",
+                "default"
+            ),
+            "2023-06-03",
+            "2023-06-10",
+            PartOfDayDTO(
+                "0001",
+                "Full day",
+                "default"
+            )
+        ),
+        EventDTO(
+            "f4b20503-0a30-4e76-8796-aee787661387",
+            PolicyDTO(
+                "0006",
+                "Carnival",
+                "default"
+            ),
+            "2023-02-03",
+            "2023-02-03",
+            PartOfDayDTO(
+                "0001",
+                "Full day",
+                "default"
+            )
+        )
+
+    )
 }

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/mocks/EventApiClientMock.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/mocks/EventApiClientMock.kt
@@ -7,12 +7,16 @@ import io.ktor.http.*
 class EventApiClientMock : IEventApiClient {
 
     override suspend fun getAllEventsForUser(userId: String): Result<List<EventDTO>> {
-        TODO("Not yet implemented")
+        if (userId == DefaultTestData.USER_ID_CORRECT) {
+            return Result.success(DefaultTestData.EVENT_LIST)
+        }
+        return Result.failure(Exception(HttpStatusCode.NotFound.description))
     }
 
     override suspend fun removeEventById(userId: String, eventId: String): Result<Nothing?> {
-        if (userId == DefaultTestData.USER_ID_CORRECT && eventId == DefaultTestData.EVENT_ID_CORRECT)
+        if (userId == DefaultTestData.USER_ID_CORRECT && eventId == DefaultTestData.EVENT_ID_CORRECT) {
             return Result.success(null)
+        }
         return Result.failure(Exception(HttpStatusCode.NotFound.description))
     }
 }

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/mocks/EventApiClientMock.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/mocks/EventApiClientMock.kt
@@ -1,9 +1,14 @@
 package com.mindera.minderapeople.mocks
 
 import com.mindera.minderapeople.apiclient.interfaces.IEventApiClient
+import com.mindera.minderapeople.dto.EventDTO
 import io.ktor.http.*
 
-class EventApiClientMock: IEventApiClient {
+class EventApiClientMock : IEventApiClient {
+
+    override suspend fun getAllEventsForUser(userId: String): Result<List<EventDTO>> {
+        TODO("Not yet implemented")
+    }
 
     override suspend fun removeEventById(userId: String, eventId: String): Result<Nothing?> {
         if (userId == DefaultTestData.USER_ID_CORRECT && eventId == DefaultTestData.EVENT_ID_CORRECT)

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/apiclient/EventApiClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/apiclient/EventApiClientTest.kt
@@ -1,15 +1,76 @@
 package com.mindera.minderapeople.unit.apiclient
 
 import com.mindera.minderapeople.apiclient.EventApiClient
+import com.mindera.minderapeople.mocks.DefaultTestData
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 class EventApiClientTest {
+
+    @Test
+    fun getAllEventsForUser_successful() {
+        val mockEngine = MockEngine {
+            respond(
+                content = ByteReadChannel(Json.encodeToString(DefaultTestData.EVENT_LIST)),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+
+        runBlocking {
+            val client = EventApiClient(mockEngine)
+            val result = client.getAllEventsForUser("3b1276b3-d2f6-4e29-af8f-a0cb00208dda")
+
+            assertTrue(result.isSuccess)
+            assertNotEquals(null, result.getOrNull())
+            assertEquals(DefaultTestData.EVENT_LIST, result.getOrNull())
+        }
+    }
+
+    @Test
+    fun getAllEventsForUser_userNotFound() {
+        val mockEngine = MockEngine {
+            respond(
+                content = ByteReadChannel(""),
+                status = HttpStatusCode.NotFound,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+
+        runBlocking {
+            val client = EventApiClient(mockEngine)
+            val result = client.getAllEventsForUser("0001")
+
+            assertTrue(result.isFailure)
+            assertEquals(null, result.getOrNull())
+            assertEquals(HttpStatusCode.NotFound.description, result.exceptionOrNull()?.message)
+        }
+    }
+
+    @Test
+    fun getAllEventsForUser_exceptionThrown() {
+        val error = "Error occurred"
+        val mockEngine = MockEngine {
+            throw Exception(error)
+        }
+
+        runBlocking {
+            val client = EventApiClient(mockEngine)
+            val result = client.getAllEventsForUser("3b1276b3-d2f6-4e29-af8f-a0cb00208dda")
+
+            assertTrue(result.isFailure)
+            assertEquals(null, result.getOrNull())
+            assertEquals(error, result.exceptionOrNull()?.message)
+        }
+    }
 
     @Test
     fun removeEventById_successful() {

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/apiclient/EventApiClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/apiclient/EventApiClientTest.kt
@@ -1,4 +1,4 @@
-package com.mindera.minderapeople.unit.apiclient
+package com.mindera.minderapeople.unit.apiClient
 
 import com.mindera.minderapeople.apiclient.EventApiClient
 import com.mindera.minderapeople.mocks.DefaultTestData
@@ -27,7 +27,7 @@ class EventApiClientTest {
 
         runBlocking {
             val client = EventApiClient(mockEngine)
-            val result = client.getAllEventsForUser("3b1276b3-d2f6-4e29-af8f-a0cb00208dda")
+            val result = client.getAllEventsForUser("correctUserId")
 
             assertTrue(result.isSuccess)
             assertNotEquals(null, result.getOrNull())
@@ -38,16 +38,12 @@ class EventApiClientTest {
     @Test
     fun getAllEventsForUser_userNotFound() {
         val mockEngine = MockEngine {
-            respond(
-                content = ByteReadChannel(""),
-                status = HttpStatusCode.NotFound,
-                headers = headersOf(HttpHeaders.ContentType, "application/json")
-            )
+            respondError(HttpStatusCode.NotFound)
         }
 
         runBlocking {
             val client = EventApiClient(mockEngine)
-            val result = client.getAllEventsForUser("0001")
+            val result = client.getAllEventsForUser("unknownUserId")
 
             assertTrue(result.isFailure)
             assertEquals(null, result.getOrNull())
@@ -64,7 +60,7 @@ class EventApiClientTest {
 
         runBlocking {
             val client = EventApiClient(mockEngine)
-            val result = client.getAllEventsForUser("3b1276b3-d2f6-4e29-af8f-a0cb00208dda")
+            val result = client.getAllEventsForUser("correctUserId")
 
             assertTrue(result.isFailure)
             assertEquals(null, result.getOrNull())
@@ -85,8 +81,8 @@ class EventApiClientTest {
         runBlocking {
             val client = EventApiClient(mockEngine)
             val result = client.removeEventById(
-                "3b1276b3-d2f6-4e29-af8f-a0cb00208dda",
-                "f4b20503-0a59-4e76-8796-aee78726139f"
+                "correctUserId",
+                "correctEventId"
             )
 
             assertTrue(result.isSuccess)
@@ -107,8 +103,8 @@ class EventApiClientTest {
         runBlocking {
             val client = EventApiClient(mockEngine)
             val result = client.removeEventById(
-                "3b1276b3-d2f6-4e29-af8f-accb00208dda",
-                "f4b20503-0a59-4e76-8796-aee78726139f"
+                "correctUserId",
+                "unknownEventId"
             )
 
             assertEquals(null, result.getOrNull())
@@ -127,8 +123,8 @@ class EventApiClientTest {
         runBlocking {
             val client = EventApiClient(mockEngine)
             val result = client.removeEventById(
-                "3b1276b3-d2f6-4e29-af8f-a0cb00208dda",
-                "f4b20503-0a59-4e76-8796-aee78726139f"
+                "correctUserId",
+                "correctEventId"
             )
 
             assertEquals(null, result.getOrNull())

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/repository/EventRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/repository/EventRepositoryTest.kt
@@ -12,6 +12,33 @@ import kotlin.test.assertTrue
 class EventRepositoryTest {
 
     @Test
+    fun getAllEventsForUser_successful() {
+        val client = EventApiClientMock()
+        val repo = EventRepository(client)
+
+        runBlocking {
+            val result = repo.getAllEventsForUser(DefaultTestData.USER_ID_CORRECT)
+
+            assertTrue(result.isSuccess)
+            assertEquals(DefaultTestData.EVENT_LIST, result.getOrNull())
+        }
+    }
+
+    @Test
+    fun getAllEventsForUser_userNotFound() {
+        val client = EventApiClientMock()
+        val repo = EventRepository(client)
+
+        runBlocking {
+            val result = repo.getAllEventsForUser("0001")
+
+            assertTrue(result.isFailure)
+            assertEquals(null, result.getOrNull())
+            assertEquals(HttpStatusCode.NotFound.description, result.exceptionOrNull()?.message)
+        }
+    }
+
+    @Test
     fun removeEventById_successful() {
         val client = EventApiClientMock()
         val repo = EventRepository(client)

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/repository/EventRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/repository/EventRepositoryTest.kt
@@ -30,7 +30,7 @@ class EventRepositoryTest {
         val repo = EventRepository(client)
 
         runBlocking {
-            val result = repo.getAllEventsForUser("0001")
+            val result = repo.getAllEventsForUser("unknownUserId")
 
             assertTrue(result.isFailure)
             assertEquals(null, result.getOrNull())
@@ -56,7 +56,7 @@ class EventRepositoryTest {
         val repo = EventRepository(client)
 
         runBlocking {
-            val result = repo.removeEventById("3b1276b3-d2f6-4e29-af8f-a0cb00208dcc", DefaultTestData.CORRECT_EVENT)
+            val result = repo.removeEventById("unknownUserId", DefaultTestData.CORRECT_EVENT)
             assertTrue(result.isFailure)
             assertEquals(HttpStatusCode.NotFound.description, result.exceptionOrNull()?.message)
         }

--- a/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/repository/PolicyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mindera/minderapeople/unit/repository/PolicyRepositoryTest.kt
@@ -6,11 +6,9 @@ import com.mindera.minderapeople.mocks.DefaultTestData
 import com.mindera.minderapeople.mocks.PolicyApiClientMock
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
-
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
 
 class PolicyRepositoryTest {
 


### PR DESCRIPTION
This PR has the code implementation that performs requests to the backend API to retrieve all the events for a certain user

It's implemented according to the following diagram:
![ListAllEvent](https://user-images.githubusercontent.com/126101431/229868878-c4689a1c-2a39-41d3-ac75-83c3be289f58.svg)
